### PR TITLE
use svg space as "world space"

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -11,3 +11,9 @@ In practice, these libraries require additional infrastructure to run a visual p
 - `/apps/nodepen-client` A next.js frontend that consumes `@nodepen/nodes` and provides example callbacks.
 - `/apps/rhino-compute-server` A Rhino.Compute backend that accepts requests from the client, computes solutions, and writes updates to the given Speckle stream.
 - `/apps/speckle-server` A git submodule of `speckle-systems/speckle-server`. Used to run a Speckle server locally.
+
+## Coordinate Systems
+
+**Page Space** - Coordinates that correspond to the browser's `pageX` and `pageY` space. This is regardless of the size or position of the root canvas div on the page (and, as a result, probably doesn't play nicely with scroll right now.)
+
+**World Space** - Coordinates that correspond to the main canvas `svg` element.

--- a/packages/converters/NodePenConvert.cs
+++ b/packages/converters/NodePenConvert.cs
@@ -173,7 +173,7 @@ namespace NodePen.Converters
                             };
 
                             node.Position.X = component.Attributes.Pivot.X * 2;
-                            node.Position.Y = component.Attributes.Pivot.Y * -2;
+                            node.Position.Y = component.Attributes.Pivot.Y * 2;
 
                             for (var i = 0; i < component.Params.Input.Count; i++)
                             {

--- a/packages/nodes/src/components/annotations/wire/Wire.tsx
+++ b/packages/nodes/src/components/annotations/wire/Wire.tsx
@@ -56,9 +56,9 @@ const Wire = ({ from, to }: WireProps): React.ReactElement | null => {
   const bRightAnchor = pointAt([end.x, end.y], [endLead.x, endLead.y], 0.7)
 
   const d = [
-    `M ${start.x} ${-start.y}`,
-    `C ${aLeftAnchor.x} ${-aLeftAnchor.y} ${aRightAnchor.x} ${-aRightAnchor.y} ${mid.x} ${-mid.y}`,
-    `S ${bRightAnchor.x} ${-bRightAnchor.y} ${end.x} ${-end.y}`,
+    `M ${start.x} ${start.y}`,
+    `C ${aLeftAnchor.x} ${aLeftAnchor.y} ${aRightAnchor.x} ${aRightAnchor.y} ${mid.x} ${mid.y}`,
+    `S ${bRightAnchor.x} ${bRightAnchor.y} ${end.x} ${end.y}`,
   ].join('')
 
   const getWireStyle = (structure: DataTreeStructure) => {

--- a/packages/nodes/src/components/nodes/generic-node/GenericNode.tsx
+++ b/packages/nodes/src/components/nodes/generic-node/GenericNode.tsx
@@ -35,7 +35,7 @@ const GenericNode = ({ id, template }: GenericNodeProps): React.ReactElement => 
         {/* Shadow */}
         <rect
           x={position.x}
-          y={-position.y + 2}
+          y={position.y + 2}
           width={nodeWidth}
           height={nodeHeight}
           rx={7}
@@ -53,13 +53,13 @@ const GenericNode = ({ id, template }: GenericNodeProps): React.ReactElement => 
 
           const portPosition = {
             x: position.x + portAnchor.dx - NODE_PORT_RADIUS,
-            y: position.y + portAnchor.dy + NODE_PORT_RADIUS,
+            y: position.y + portAnchor.dy - NODE_PORT_RADIUS,
           }
 
           return (
             <rect
               x={portPosition.x}
-              y={-portPosition.y}
+              y={portPosition.y}
               width={NODE_PORT_RADIUS * 2}
               height={NODE_PORT_RADIUS * 2 + 2}
               rx={NODE_PORT_RADIUS}
@@ -73,7 +73,7 @@ const GenericNode = ({ id, template }: GenericNodeProps): React.ReactElement => 
         {/* Body */}
         <rect
           x={position.x}
-          y={-position.y}
+          y={position.y}
           width={nodeWidth}
           height={nodeHeight}
           rx={7}
@@ -86,7 +86,7 @@ const GenericNode = ({ id, template }: GenericNodeProps): React.ReactElement => 
         {/* Label */}
         <rect
           x={position.x + nodeWidth / 2 - NODE_LABEL_WIDTH / 2}
-          y={-position.y + NODE_INTERNAL_PADDING}
+          y={position.y + NODE_INTERNAL_PADDING}
           width={NODE_LABEL_WIDTH}
           height={nodeHeight - NODE_INTERNAL_PADDING * 2}
           rx={7}
@@ -99,9 +99,9 @@ const GenericNode = ({ id, template }: GenericNodeProps): React.ReactElement => 
         <path
           id={`node-label-${id}`}
           fill="none"
-          d={`M ${position.x + nodeWidth / 2 + NODE_LABEL_FONT_SIZE / 2 - 3} ${-position.y + nodeHeight} L ${
+          d={`M ${position.x + nodeWidth / 2 + NODE_LABEL_FONT_SIZE / 2 - 3} ${position.y + nodeHeight} L ${
             position.x + nodeWidth / 2 + NODE_LABEL_FONT_SIZE / 2 - 3
-          } ${-position.y}`}
+          } ${position.y}`}
         />
         <text className="np-font-panel np-select-none" fill={COLORS.DARK} fontSize={NODE_LABEL_FONT_SIZE}>
           <textPath href={`#node-label-${id}`} startOffset="50%" textAnchor="middle" alignmentBaseline="middle">

--- a/packages/nodes/src/components/nodes/generic-node/components/GenericNodePort.tsx
+++ b/packages/nodes/src/components/nodes/generic-node/components/GenericNodePort.tsx
@@ -28,7 +28,7 @@ const GenericNodePort = ({ nodeInstanceId, portInstanceId, template }: GenericNo
         x: direction === 'input'
             ? position.x + NODE_PORT_LABEL_OFFSET
             : position.x - NODE_PORT_LABEL_OFFSET,
-        y: position.y - 1.5 - NODE_PORT_LABEL_FONT_SIZE / 4
+        y: position.y + 1.5 + NODE_PORT_LABEL_FONT_SIZE / 4
     }
 
     const labelTextAnchor = direction === 'input' ? 'start' : 'end'
@@ -38,14 +38,14 @@ const GenericNodePort = ({ nodeInstanceId, portInstanceId, template }: GenericNo
             <circle
                 r={NODE_PORT_RADIUS}
                 cx={position.x}
-                cy={-position.y}
+                cy={position.y}
                 fill={COLORS.LIGHT}
                 stroke={COLORS.DARK}
                 strokeWidth={2}
             />
             <text
                 x={labelPosition.x}
-                y={-labelPosition.y}
+                y={labelPosition.y}
                 className="np-font-mono np-select-none"
                 fontSize={NODE_PORT_LABEL_FONT_SIZE}
                 fill={COLORS.DARK}

--- a/packages/nodes/src/components/nodes/hooks/useDraggableNode.ts
+++ b/packages/nodes/src/components/nodes/hooks/useDraggableNode.ts
@@ -81,7 +81,7 @@ export const useDraggableNode = (nodeInstanceId: string): React.RefObject<SVGGEl
 
     // TODO: Include zoom
     const dx = (currentPointerX - initialPointerX) / zoom.current
-    const dy = ((currentPointerY - initialPointerY) * -1) / zoom.current
+    const dy = (currentPointerY - initialPointerY) / zoom.current
 
     const { x: initialNodeX, y: initialNodeY } = initialNodePosition.current
 

--- a/packages/nodes/src/hooks/usePageSpaceToWorldSpace.ts
+++ b/packages/nodes/src/hooks/usePageSpaceToWorldSpace.ts
@@ -35,13 +35,13 @@ export const usePageSpaceToWorldSpace = (): (pageX: number, pageY: number) => [x
         // Cursor position, relative to camera position, in world units
         const relativeCursorPositionWorldSpace = {
             x: relativeCursorPositionPageSpace.x / zoom,
-            y: relativeCursorPositionPageSpace.y / -zoom
+            y: relativeCursorPositionPageSpace.y / zoom
         }
 
         // Cursor position in world units
         const absoluteCursorPositionWorldSpace = {
             x: relativeCursorPositionWorldSpace.x + position.x,
-            y: relativeCursorPositionWorldSpace.y + position.y
+            y: relativeCursorPositionWorldSpace.y - position.y
         }
 
         return [absoluteCursorPositionWorldSpace.x, absoluteCursorPositionWorldSpace.y]

--- a/packages/nodes/src/store/dispatch.ts
+++ b/packages/nodes/src/store/dispatch.ts
@@ -10,7 +10,7 @@ import { expireSolution } from './utils'
 
 const { NODE_INTERNAL_PADDING } = DIMENSIONS
 
-type BaseAction = string | ({ type: string } &  Record<string, unknown>)
+type BaseAction = string | ({ type: string } & Record<string, unknown>)
 type BaseSetter = (callback: (state: NodesAppState) => void, replace?: boolean, action?: BaseAction) => void
 type BaseGetter = () => NodesAppState
 
@@ -49,7 +49,7 @@ export const createDispatch = (set: BaseSetter, get: BaseGetter) => {
             const currentDomain = inputHeightSegments[i]
 
             const deltaX = 0
-            const deltaY = (remap(0.5, [0, 1], currentDomain) * -1) - NODE_INTERNAL_PADDING
+            const deltaY = remap(0.5, [0, 1], currentDomain) + NODE_INTERNAL_PADDING
 
             node.anchors[currentId] = {
               dx: deltaX,
@@ -65,7 +65,7 @@ export const createDispatch = (set: BaseSetter, get: BaseGetter) => {
             const currentDomain = outputHeightSegments[i]
 
             const deltaX = nodeWidth
-            const deltaY = (remap(0.5, [0, 1], currentDomain) * -1) - NODE_INTERNAL_PADDING
+            const deltaY = remap(0.5, [0, 1], currentDomain) + NODE_INTERNAL_PADDING
 
             node.anchors[currentId] = {
               dx: deltaX,

--- a/packages/nodes/src/views/document-view/components/camera-overlay/CameraOverlay.tsx
+++ b/packages/nodes/src/views/document-view/components/camera-overlay/CameraOverlay.tsx
@@ -150,14 +150,14 @@ const CameraOverlay = ({ children }: CameraControlProps): React.ReactElement => 
     const { x: cameraWorldX, y: cameraWorldY } = useStore.getState().camera.position
 
     const vec = {
-      x: cameraWorldX - cursorWorldX,
-      y: cameraWorldY - cursorWorldY,
+      x: cursorWorldX - cameraWorldX,
+      y: cursorWorldY - (cameraWorldY * -1),
     }
 
     const zoomDelta = nextZoom - zoom.current
 
     const transform = {
-      x: (vec.x / nextZoom) * -zoomDelta,
+      x: (vec.x / nextZoom) * zoomDelta,
       y: (vec.y / nextZoom) * -zoomDelta,
     }
 


### PR DESCRIPTION
I let myself lapse into just toggling +/- coordinates to make stuff render correctly. It got inconsistent and difficult to reason about.

Now:

"page space" means literal page space, as in `pageX` and `pageY`
"world space" means literal svg space, as in +y goes down

So nodes should render with `position.y` type values as-is, instead of adding an additional positive/negative toggle.