### PR TITLE
Apply user-set values correctly

### DIFF
--- a/packages/converters/NodePenConvert.cs
+++ b/packages/converters/NodePenConvert.cs
@@ -295,12 +295,12 @@ namespace NodePen.Converters
                                     continue;
                                 }
 
-                                param.ClearData();
-
                                 switch (param)
                                 {
                                     case Param_Number numberParam:
                                         {
+                                            numberParam.PersistentData.ClearData();
+
                                             var valueGoo = new GH_Number(value.UnwrapAsDouble());
 
                                             var tree = new GH_Structure<GH_Number>();
@@ -309,10 +309,13 @@ namespace NodePen.Converters
                                             tree.Insert(valueGoo, branch, 0);
 
                                             numberParam.SetPersistentData(tree, branch, valueGoo);
+                                            numberParam.OnObjectChanged(GH_ObjectEventType.PersistentData);
                                             break;
                                         }
                                     case Param_Integer integerParam:
                                         {
+                                            integerParam.PersistentData.ClearData();
+
                                             var valueGoo = new GH_Integer(value.UnwrapAsInteger());
 
                                             var tree = new GH_Structure<GH_Integer>();
@@ -321,6 +324,7 @@ namespace NodePen.Converters
                                             tree.Insert(valueGoo, branch, 0);
 
                                             integerParam.SetPersistentData(tree, branch, valueGoo);
+                                            integerParam.OnObjectChanged(GH_ObjectEventType.PersistentData);
                                             break;
                                         }
                                     default:
@@ -329,6 +333,7 @@ namespace NodePen.Converters
                                             break;
                                         }
                                 }
+
                             }
 
                             foreach (var outputInstanceId in node.Outputs.Keys)

--- a/packages/nodes/tailwind.config.js
+++ b/packages/nodes/tailwind.config.js
@@ -20,7 +20,7 @@ module.exports = {
     },
     extend: {
       animation: {
-        'menu-appear': 'menu-appear 125ms ease-in'
+        'menu-appear': 'menu-appear 125ms ease-in forwards'
       },
       keyframes: {
         'menu-appear': {


### PR DESCRIPTION
I was incorrectly using `param.SetPersistentData` when user-set values were declared. In short, I wasn't properly clearing default values. So, the user value would be set _in addition_ to the default, creating unexpected results.

I'm not happy with how much repetition is going on here but I'm sure there's a way to do pre-set and post-set work more generically. Will tackle that later.