### PR TITLE
Tune wire graphics, improve search

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,10 +56,6 @@ A thin next.js client that communicates directly with the Rhino Compute server f
 
 A minimal Rhino Compute server with endpoints for updating a given NodePen document. Writes results directly to the local Speckle server instance it's configured to point to.
 
-#### speckle-server
-
-A git submodule of [specklesystems/speckle-server](https://github.com/specklesystems/speckle-server).
-
 ## Local Development
 
 Running NodePen locally requires a number of dependencies and, at the moment, a bit of manual work for first-time setup. Please also see the section below about known limitations.
@@ -76,10 +72,10 @@ In order to run all of the example applications, you will need:
 
 ### Initial Setup
 
-Clone this repo and its speckle-server submodule with:
+Clone this repo:
 
 ```
-git clone --recurse-submodules git@github.com:nodepen/nodes.git
+git clone git@github.com:nodepen/nodes.git
 ```
 
 From the root directory, run:
@@ -89,7 +85,7 @@ npm i
 npm run build
 ```
 
-This should install dependencies for all of the javascript projects and build them once. Build failures may occur for the last project, `nodepen-client`, and can be ignored.
+This should install dependencies for all of the javascript projects and build them once. Build failures may still occur for the last project, `nodepen-client`, and can be ignored.
 
 From `/apps/rhino-compute-server` run:
 
@@ -117,7 +113,7 @@ At this point, you may leave your Speckle server running and continue onto the n
 
 ### Development Environment
 
-All three services in the `/apps` directory must be running in order to develop with NodePen locally. In general, I recommend letting all three run in their own terminal. In VSCode, you can split terminals to see results from each one at the same time.
+Both services in the `/apps` directory must be running in order to develop with NodePen locally. For all current features, you must also have access to a running speckle server (local or otherwise).
 
 Once all three are successfully running, you can navigate to `http://localhost:4000` to begin working.
 

--- a/apps/rhino-compute-server/Endpoints/GrasshopperEndpoints.cs
+++ b/apps/rhino-compute-server/Endpoints/GrasshopperEndpoints.cs
@@ -21,9 +21,9 @@ namespace Rhino.Compute.Endpoints
 
   public class GrasshopperEndpointsModule : NancyModule
   {
-    public static string STREAM_ID = "002acf71a3";
+    public static string STREAM_ID = "8f152cb7a4";
     public static string STREAM_URL = "http://localhost:3000";
-    public static string STREAM_TOKEN = "afb6675115b6e5e88847509faa7567148b2fc862cb";
+    public static string STREAM_TOKEN = "5786dd5155738317691e81c1facb9d7a19d5c27320";
 
     public GrasshopperEndpointsModule(IRouteCacheProvider routeCacheProvider)
     {

--- a/packages/nodes/src/components/annotations/wire/Wire.tsx
+++ b/packages/nodes/src/components/annotations/wire/Wire.tsx
@@ -65,42 +65,55 @@ export const Wire = ({
 
   const NODE_BACKGROUND_STROKE = structure === 'single' ? 6 : 10
 
+  // The graphics for either the wire proper or its mask
   const getWireGraphics = (structure: DataTreeStructure) => {
-    switch (structure) {
-      case 'empty':
-      case 'single': {
-        return (
-          <path
-            d={d}
-            strokeWidth={drawMask ? 5 : 3}
-            stroke={drawMask ? '#FFFFFF' : COLORS.DARK}
-            fill="none"
-            strokeLinecap="round"
-          />
-        )
+    if (drawMask) {
+      switch (structure) {
+        case 'empty':
+        case 'single': {
+          return <path d={d} strokeWidth={5} stroke="#FFFFFF" fill="none" strokeLinecap="round" />
+        }
+        case 'list':
+        case 'tree': {
+          return <path d={d} strokeWidth={9} stroke="#FFFFFF" fill="none" strokeLinecap="round" />
+        }
       }
-      case 'list': {
-        return (
-          <>
-            <path d={d} strokeWidth={7} stroke={COLORS.DARK} fill="none" strokeLinecap="round" />
-            <path d={d} strokeWidth={3} stroke={COLORS.LIGHT} fill="none" strokeLinecap="round" />
-          </>
-        )
-      }
-      case 'tree': {
-        return (
-          <>
-            <path d={d} strokeWidth={7} stroke={COLORS.DARK} strokeDasharray="6 10" strokeLinecap="round" fill="none" />
-            <path
-              d={d}
-              strokeWidth={3}
-              stroke={COLORS.LIGHT}
-              strokeDasharray="6 10"
-              strokeLinecap="round"
-              fill="none"
-            />
-          </>
-        )
+    } else {
+      switch (structure) {
+        case 'empty':
+        case 'single': {
+          return <path d={d} strokeWidth={3} stroke={COLORS.DARK} fill="none" strokeLinecap="round" />
+        }
+        case 'list': {
+          return (
+            <>
+              <path d={d} strokeWidth={7} stroke={COLORS.DARK} fill="none" strokeLinecap="round" />
+              <path d={d} strokeWidth={3} stroke={COLORS.LIGHT} fill="none" strokeLinecap="round" />
+            </>
+          )
+        }
+        case 'tree': {
+          return (
+            <>
+              <path
+                d={d}
+                strokeWidth={7}
+                stroke={COLORS.DARK}
+                strokeDasharray="6 10"
+                strokeLinecap="round"
+                fill="none"
+              />
+              <path
+                d={d}
+                strokeWidth={3}
+                stroke={COLORS.LIGHT}
+                strokeDasharray="6 10"
+                strokeLinecap="round"
+                fill="none"
+              />
+            </>
+          )
+        }
       }
     }
   }
@@ -193,6 +206,7 @@ export const Wire = ({
     if (!drawNodeBackground) {
       return null
     }
+
     return (
       <defs>
         <clipPath id="live-wire-background-clip-light">

--- a/packages/nodes/src/views/document-view/layers/transient-element-overlay/context-menus/add-node-context-menu/AddNodeContextMenu.tsx
+++ b/packages/nodes/src/views/document-view/layers/transient-element-overlay/context-menus/add-node-context-menu/AddNodeContextMenu.tsx
@@ -30,7 +30,7 @@ export const AddNodeContextMenu = ({ position: eventPosition }: AddNodeContextMe
   const [searchQuery, setSearchQuery] = useState<string>()
   const [_isPending, startTransition] = useTransition()
 
-  const candidates = useTextSearch(templates, searchQuery ?? '', ['name', 'nickName'], 'jw')
+  const candidates = useTextSearch(templates, searchQuery ?? '', ['name', 'nickName', 'keywords'], 'jw')
 
   const updateSearchQuery = useCallback(() => {
     const element = searchQueryInputRef.current

--- a/packages/nodes/src/views/document-view/layers/transient-element-overlay/context-menus/add-node-context-menu/AddNodeContextMenu.tsx
+++ b/packages/nodes/src/views/document-view/layers/transient-element-overlay/context-menus/add-node-context-menu/AddNodeContextMenu.tsx
@@ -30,7 +30,7 @@ export const AddNodeContextMenu = ({ position: eventPosition }: AddNodeContextMe
   const [searchQuery, setSearchQuery] = useState<string>()
   const [_isPending, startTransition] = useTransition()
 
-  const { exactMatch, candidates } = useTextSearch(templates, searchQuery ?? '', ['name', 'nickName', 'keywords'])
+  const candidates = useTextSearch(templates, searchQuery ?? '', ['name', 'nickName'], 'jw')
 
   const updateSearchQuery = useCallback(() => {
     const element = searchQueryInputRef.current
@@ -46,9 +46,7 @@ export const AddNodeContextMenu = ({ position: eventPosition }: AddNodeContextMe
 
   const debounceUpdateSearchQuery = useDebounceCallback(updateSearchQuery, 200)
 
-  const searchResults = exactMatch
-    ? [...candidates.slice(0, 3).reverse(), exactMatch]
-    : candidates.slice(0, 4).reverse()
+  const searchResults = candidates.slice(0, 4).reverse()
 
   useEffect(() => {
     const element = searchQueryInputRef.current
@@ -70,11 +68,17 @@ export const AddNodeContextMenu = ({ position: eventPosition }: AddNodeContextMe
     (e: React.KeyboardEvent<HTMLDivElement>): void => {
       switch (e.key) {
         case 'ArrowUp': {
+          e.preventDefault()
+
           setInternalSelection(clamp(internalSelection - 1, 0, 3))
+
           break
         }
         case 'ArrowDown': {
+          e.preventDefault()
+
           setInternalSelection(clamp(internalSelection + 1, 0, 3))
+
           break
         }
         case 'Enter': {

--- a/packages/nodes/src/views/document-view/layers/transient-element-overlay/context-menus/add-node-context-menu/hooks/useTextSearch.ts
+++ b/packages/nodes/src/views/document-view/layers/transient-element-overlay/context-menus/add-node-context-menu/hooks/useTextSearch.ts
@@ -1,4 +1,4 @@
-import { levenshteinDistance } from '../utils'
+import { exactDistance, jaroWinklerDistance, levenshteinDistance } from '../utils'
 import { useMemo } from 'react'
 
 /**
@@ -25,12 +25,7 @@ type RequireStringKeys<T extends Record<string | number | symbol, unknown>> = ke
   Exclude<keyof T, number | symbol>
 >
 
-type SearchResult<T> = {
-  candidates: T[]
-  exactMatch?: T
-}
-
-// TODO: Use a better text comparison algorithm
+type SearchAlgorithmKey = 'lev' | 'jw' | 'exact'
 
 /**
  * @param items The collection of objects to run the search against.
@@ -40,67 +35,57 @@ type SearchResult<T> = {
 export const useTextSearch = <T extends Record<string, unknown>>(
   items: T[],
   search: string,
-  keys: RequireStringKeys<PickStringOrStringArrayValue<T>>[]
-): SearchResult<T> => {
-  const getSortValue = (item: T, search: string): number => {
-    const sortValues = keys
-      .reduce((allTerms, key) => {
-        const targetValue = item[key] as PickStringOrStringArrayValue<T>[keyof PickStringOrStringArrayValue<T>]
+  keys: RequireStringKeys<PickStringOrStringArrayValue<T>>[],
+  searchAlgorithm: SearchAlgorithmKey = 'lev',
+  searchResultLimit = 20
+): T[] => {
+  // Map each object to an array of string values at specified search keys
+  const searchValues: [string[], number][] = useMemo(() => {
+    return items.map((item, i) => {
+      const searchValuesForItem: string[] = []
+
+      for (const key of keys) {
+        const targetValue = item[key]
 
         switch (typeof targetValue) {
           case 'object': {
             if (!Array.isArray(targetValue)) {
-              return allTerms
+              continue
             }
 
-            return [...allTerms, ...targetValue]
+            searchValuesForItem.push(...targetValue)
+
+            break
           }
           case 'string': {
-            return [...allTerms, targetValue]
+            searchValuesForItem.push(targetValue)
+            break
           }
           default: {
-            return allTerms
+            break
           }
         }
-      }, [] as string[])
-      .map((term) => levenshteinDistance(term.toLowerCase(), search.toLowerCase()))
+      }
 
-    return Math.min(...sortValues)
-  }
+      return [searchValuesForItem, i]
+    })
+  }, [items, keys])
 
-  const searchCandidates = items
-
-  const result: SearchResult<T> = useMemo(() => {
-    const defaultResult: SearchResult<T> = {
-      candidates: searchCandidates,
+  const sortResult = useMemo(() => {
+    const searchAlgorithms: Record<SearchAlgorithmKey, (a: string, b: string) => number> = {
+      lev: levenshteinDistance,
+      jw: (a, b) => 1 - jaroWinklerDistance(a, b),
+      exact: exactDistance,
     }
 
-    if (!search || search.length <= 0) {
-      return defaultResult
+    const compare = searchAlgorithms[searchAlgorithm]
+
+    const getSearchValue = (values: string[]): number => {
+      return Math.min(...values.map((value) => compare(value.toLowerCase(), search.toLowerCase())))
     }
 
-    const exactMatch = undefined
+    return searchValues.sort((a, b) => getSearchValue(a[0]) - getSearchValue(b[0]))
+  }, [searchValues, search, searchAlgorithm])
 
-    // const exactMatch = searchCandidates.find((candidate) => {
-    //   for (const key of keys) {
-    //     const value = candidate[key]
-
-    //     if (typeof value !== 'string') {
-    //       continue
-    //     }
-
-    //     if (value.toLowerCase() === search) {
-    //       return true
-    //     }
-    //   }
-
-    //   return false
-    // })
-
-    const candidates = searchCandidates.sort((a, b) => getSortValue(a, search) - getSortValue(b, search))
-
-    return { candidates, exactMatch }
-  }, [search, searchCandidates])
-
-  return result
+  return sortResult.slice(0, searchResultLimit).map(([_keys, originalIndex]) => items[originalIndex])
 }

--- a/packages/nodes/src/views/document-view/layers/transient-element-overlay/context-menus/add-node-context-menu/hooks/useTextSearch.ts
+++ b/packages/nodes/src/views/document-view/layers/transient-element-overlay/context-menus/add-node-context-menu/hooks/useTextSearch.ts
@@ -37,7 +37,11 @@ export const useTextSearch = <T extends Record<string, unknown>>(
   search: string,
   keys: RequireStringKeys<PickStringOrStringArrayValue<T>>[],
   searchAlgorithm: SearchAlgorithmKey = 'lev',
-  searchResultThreshold = 0,
+  /**
+   * Only return results with search value less than threshold.
+   * Values are between 0 and 1, with lower values meaning a better match.
+   */
+  searchResultThreshold = 1,
   searchResultLimit = 20
 ): T[] => {
   // Map each object to an array of string values at specified search keys
@@ -87,7 +91,7 @@ export const useTextSearch = <T extends Record<string, unknown>>(
 
     return searchValues
       .map(([values, originalIndex]): [number, number] => [getSearchValue(values), originalIndex])
-      .filter(([searchValue]) => searchValue > searchResultThreshold)
+      .filter(([searchValue]) => searchValue <= searchResultThreshold)
       .sort((a, b) => a[0] - b[0])
   }, [search, searchValues, searchAlgorithm])
 

--- a/packages/nodes/src/views/document-view/layers/transient-element-overlay/context-menus/add-node-context-menu/utils/exactDistance.ts
+++ b/packages/nodes/src/views/document-view/layers/transient-element-overlay/context-menus/add-node-context-menu/utils/exactDistance.ts
@@ -1,3 +1,3 @@
 export const exactDistance = (a: string, b: string): number => {
-  return a.toUpperCase() === b.toUpperCase() ? 1 : 0
+  return a.toUpperCase() === b.toUpperCase() ? 0 : 1
 }

--- a/packages/nodes/src/views/document-view/layers/transient-element-overlay/context-menus/add-node-context-menu/utils/exactDistance.ts
+++ b/packages/nodes/src/views/document-view/layers/transient-element-overlay/context-menus/add-node-context-menu/utils/exactDistance.ts
@@ -1,0 +1,3 @@
+export const exactDistance = (a: string, b: string): number => {
+  return a.toUpperCase() === b.toUpperCase() ? 1 : 0
+}

--- a/packages/nodes/src/views/document-view/layers/transient-element-overlay/context-menus/add-node-context-menu/utils/index.ts
+++ b/packages/nodes/src/views/document-view/layers/transient-element-overlay/context-menus/add-node-context-menu/utils/index.ts
@@ -1,1 +1,3 @@
+export { exactDistance } from './exactDistance'
+export { jaroWinklerDistance } from './jaroWinklerDistance'
 export { levenshteinDistance } from './levenshteinDistance'

--- a/packages/nodes/src/views/document-view/layers/transient-element-overlay/context-menus/add-node-context-menu/utils/jaroWinklerDistance.ts
+++ b/packages/nodes/src/views/document-view/layers/transient-element-overlay/context-menus/add-node-context-menu/utils/jaroWinklerDistance.ts
@@ -1,0 +1,166 @@
+// Courtesy of github user `thsig` 🙏
+// https://github.com/thsig/jaro-winkler-JS/blob/master/jaro_winkler.js
+
+export const jaroWinklerDistance = (a: string, b: string) => {
+  if (!a || !b) {
+    return 0.0
+  }
+
+  a = a.trim().toUpperCase()
+  b = b.trim().toUpperCase()
+  const a_len = a.length
+  const b_len = b.length
+  const a_flag = []
+  const b_flag = []
+  const search_range = Math.floor(Math.max(a_len, b_len) / 2) - 1
+  const minv = Math.min(a_len, b_len)
+
+  // Looking only within the search range, count and flag the matched pairs.
+  let Num_com = 0
+  const yl1 = b_len - 1
+  for (let i = 0; i < a_len; i++) {
+    const lowlim = i >= search_range ? i - search_range : 0
+    const hilim = i + search_range <= yl1 ? i + search_range : yl1
+    for (let j = lowlim; j <= hilim; j++) {
+      if (b_flag[j] !== 1 && a[j] === b[i]) {
+        a_flag[j] = 1
+        b_flag[i] = 1
+        Num_com++
+        break
+      }
+    }
+  }
+
+  // Return if no characters in common
+  if (Num_com === 0) {
+    return 0.0
+  }
+
+  // Count the number of transpositions
+  let k = 0
+  let N_trans = 0
+  for (let i = 0; i < a_len; i++) {
+    if (a_flag[i] === 1) {
+      let j
+      for (j = k; j < b_len; j++) {
+        if (b_flag[j] === 1) {
+          k = j + 1
+          break
+        }
+      }
+      if (a[i] !== b[j]) {
+        N_trans++
+      }
+    }
+  }
+  N_trans = Math.floor(N_trans / 2)
+
+  // Adjust for similarities in nonmatched characters
+  let N_simi = 0
+  const adjwt = adjustments
+  if (minv > Num_com) {
+    for (let i = 0; i < a_len; i++) {
+      if (!a_flag[i]) {
+        for (let j = 0; j < b_len; j++) {
+          if (!b_flag[j]) {
+            if (adjwt[a[i]] === b[j]) {
+              N_simi += 3
+              b_flag[j] = 2
+              break
+            }
+          }
+        }
+      }
+    }
+  }
+
+  const Num_sim = N_simi / 10.0 + Num_com
+
+  // Main weight computation
+  let weight = Num_sim / a_len + Num_sim / b_len + (Num_com - N_trans) / Num_com
+  weight = weight / 3
+
+  // Continue to boost the weight if the strings are similar
+  if (weight > 0.7) {
+    // Adjust for having up to the first 4 characters in common
+    const j = minv >= 4 ? 4 : minv
+    let i
+    for (i = 0; i < j && a[i] === b[i]; i++) {
+      // Empty block
+    }
+    if (i) {
+      weight += i * 0.1 * (1.0 - weight)
+    }
+
+    // Adjust for long strings.
+    // After agreeing beginning chars, at least two more must agree
+    // and the agreeing characters must be more than half of the
+    // remaining characters.
+    if (minv > 4 && Num_com > i + 1 && 2 * Num_com >= minv + i) {
+      weight += (1 - weight) * ((Num_com - i - 1) / (a_len * b_len - i * 2 + 2))
+    }
+  }
+
+  return weight
+}
+
+// The char adjustment table used above
+const adjustments: Record<string, string> = {
+  A: 'E',
+  // @ts-expect-error Algorithm expects duplicate keys
+  A: 'I',
+  // @ts-expect-error Algorithm expects duplicate keys
+  A: 'O',
+  // @ts-expect-error Algorithm expects duplicate keys
+  A: 'U',
+  B: 'V',
+  E: 'I',
+  // @ts-expect-error Algorithm expects duplicate keys
+  E: 'O',
+  // @ts-expect-error Algorithm expects duplicate keys
+  E: 'U',
+  I: 'O',
+  // @ts-expect-error Algorithm expects duplicate keys
+  I: 'U',
+  O: 'U',
+  // @ts-expect-error Algorithm expects duplicate keys
+  I: 'Y',
+  // @ts-expect-error Algorithm expects duplicate keys
+  E: 'Y',
+  C: 'G',
+  // @ts-expect-error Algorithm expects duplicate keys
+  E: 'F',
+  W: 'U',
+  // @ts-expect-error Algorithm expects duplicate keys
+  W: 'V',
+  X: 'K',
+  S: 'Z',
+  // @ts-expect-error Algorithm expects duplicate keys
+  X: 'S',
+  Q: 'C',
+  U: 'V',
+  M: 'N',
+  L: 'I',
+  // @ts-expect-error Algorithm expects duplicate keys
+  Q: 'O',
+  P: 'R',
+  // @ts-expect-error Algorithm expects duplicate keys
+  I: 'J',
+  '2': 'Z',
+  '5': 'S',
+  '8': 'B',
+  '1': 'I',
+  // @ts-expect-error Algorithm expects duplicate keys
+  '1': 'L',
+  '0': 'O',
+  // @ts-expect-error Algorithm expects duplicate keys
+  '0': 'Q',
+  // @ts-expect-error Algorithm expects duplicate keys
+  C: 'K',
+  G: 'J',
+  // @ts-expect-error Algorithm expects duplicate keys
+  E: ' ',
+  Y: ' ',
+  // @ts-expect-error Algorithm expects duplicate keys
+  S: ' ',
+}


### PR DESCRIPTION
Solutions are back and now I get to mess with how things feel. Still plenty of useful capability to add, but also plenty of obvious mistakes in performance/feel.

Fixes mask logic for non-single-value wires.
Improves search performance and quality for double-click add-node menu.

Drops the Speckle submodule from the repo because I've been running it from WSL since the update to node 18.