### PR TITLE
Runtime warning/error messages

### DIFF
--- a/apps/rhino-compute-server/Endpoints/GrasshopperEndpoints.cs
+++ b/apps/rhino-compute-server/Endpoints/GrasshopperEndpoints.cs
@@ -77,26 +77,17 @@ namespace Rhino.Compute.Endpoints
 
               nodeSolutionData.NodeRuntimeData.DurationMs = componentInstance.ProcessorTime.TotalMilliseconds;
 
-              foreach (string runtimeMessage in componentInstance.RuntimeMessages(GH_RuntimeMessageLevel.Error))
+              if (componentInstance.RuntimeMessageLevel != GH_RuntimeMessageLevel.Blank)
               {
                 NodePenNodeRuntimeDataMessage nodeRuntimeMessage = new NodePenNodeRuntimeDataMessage()
                 {
-                  Level = "error",
-                  Message = runtimeMessage
+                  Level = componentInstance.RuntimeMessageLevel.ToString().ToLower(),
+                  Message = componentInstance.RuntimeMessages(componentInstance.RuntimeMessageLevel)[0]
                 };
 
                 nodeSolutionData.NodeRuntimeData.Messages.Add(nodeRuntimeMessage);
-              }
 
-              foreach (string runtimeMessage in componentInstance.RuntimeMessages(GH_RuntimeMessageLevel.Warning))
-              {
-                NodePenNodeRuntimeDataMessage nodeRuntimeMessage = new NodePenNodeRuntimeDataMessage()
-                {
-                  Level = "warn",
-                  Message = runtimeMessage
-                };
-
-                nodeSolutionData.NodeRuntimeData.Messages.Add(nodeRuntimeMessage);
+                Console.WriteLine(nodeSolutionData.NodeRuntimeData.Messages.FirstOrDefault().Message);
               }
 
               // Collect child param solution data

--- a/packages/converters/models/NodePenNodeSolutionData.cs
+++ b/packages/converters/models/NodePenNodeSolutionData.cs
@@ -72,7 +72,7 @@ namespace NodePen.Converters
         /// The severity of the message raised.
         /// </summary>
         /// <remarks>
-        /// Valid values: "error" | "warn" | "info"
+        /// Valid values: "error" | "warning" | "info"
         /// </remarks>
         public string Level { get; set; }
 

--- a/packages/core/src/types/DocumentNode.ts
+++ b/packages/core/src/types/DocumentNode.ts
@@ -28,6 +28,11 @@ export type DocumentNode = {
       dx: number
       dy: number
     }
+    /** The horizontal center of where the node label is drawn. */
+    labelDeltaX: {
+      dx: number
+      dy: 0
+    }
   }
   /** Data providers for inputs on this node. */
   sources: {

--- a/packages/core/src/types/solution/NodeSolutionData.ts
+++ b/packages/core/src/types/solution/NodeSolutionData.ts
@@ -12,6 +12,6 @@ type NodeRuntimeData = {
 }
 
 type NodeRuntimeDataMessage = {
-  level: 'error' | 'war' | 'info'
+  level: 'error' | 'warn' | 'info'
   message: string
 }

--- a/packages/core/src/types/solution/NodeSolutionData.ts
+++ b/packages/core/src/types/solution/NodeSolutionData.ts
@@ -12,6 +12,6 @@ type NodeRuntimeData = {
 }
 
 type NodeRuntimeDataMessage = {
-  level: 'error' | 'warn' | 'info'
+  level: 'error' | 'warning' | 'info'
   message: string
 }

--- a/packages/nodes/src/app.tsx
+++ b/packages/nodes/src/app.tsx
@@ -6,6 +6,7 @@ import { useDispatch, useStore } from '$'
 import type { NodesAppCallbacks } from '$'
 import { ControlsContainer } from '@/components'
 import { FileUploadOverlayContainer, PseudoShadowsContainer } from './views/common'
+import { StaticDialogLayer } from './views/static/dialog-layer'
 
 type NodesAppProps = {
   document: NodePen.Document
@@ -89,6 +90,7 @@ const NodesAppInternal = React.memo(({ children }: NodesAppInternalProps) => {
       <FileUploadOverlayContainer />
       <ControlsContainer />
       <PseudoShadowsContainer />
+      <StaticDialogLayer />
       {children}
     </div>
   )

--- a/packages/nodes/src/components/nodes/generic-node/GenericNode.tsx
+++ b/packages/nodes/src/components/nodes/generic-node/GenericNode.tsx
@@ -5,6 +5,7 @@ import { useDebugRender, useDraggableNode, useSelectableNode } from '../hooks'
 import {
   GenericNodeBody,
   GenericNodePorts,
+  GenericNodeRuntimeMessage,
   GenericNodeShadow,
   GenericNodeSkeleton,
   GenericNodeWires,
@@ -39,6 +40,7 @@ const GenericNode = ({ id, template }: GenericNodeProps): React.ReactElement => 
             </>
           ) : (
             <>
+              <GenericNodeRuntimeMessage node={node} />
               <GenericNodeShadow node={node} template={template} />
               <GenericNodeBody node={node} template={template} />
               <GenericNodePorts node={node} template={template} />

--- a/packages/nodes/src/components/nodes/generic-node/components/GenericNodeRuntimeMessage.tsx
+++ b/packages/nodes/src/components/nodes/generic-node/components/GenericNodeRuntimeMessage.tsx
@@ -73,10 +73,11 @@ export const GenericNodeRuntimeMessage = ({ node }: GenericNodeRuntimeMessagePro
       >
         {getNodeRuntimeMessageBubble(node, messageColors[visibleMessageLevel])}
         <rect
-          className={`${visibleMessageLevel === 'error'
+          className={`${
+            visibleMessageLevel === 'error'
               ? 'np-fill-error hover:np-fill-error-2'
               : 'np-fill-warn hover:np-fill-warn-2'
-            }  hover:np-cursor-pointer np-pointer-events-auto`}
+          }  hover:np-cursor-pointer np-pointer-events-auto`}
           x={x + dx + 3 - s / 2}
           y={y + dy - 3 - s}
           width={s - 6}
@@ -88,8 +89,9 @@ export const GenericNodeRuntimeMessage = ({ node }: GenericNodeRuntimeMessagePro
           width={24}
           height={24}
           style={{
-            transform: `translate(${node.position.x + node.anchors['labelDeltaX'].dx - 12}px, ${node.position.y - 44
-              }px)`,
+            transform: `translate(${node.position.x + node.anchors['labelDeltaX'].dx - 12}px, ${
+              node.position.y - 44
+            }px)`,
           }}
           aria-hidden="true"
           fill="none"

--- a/packages/nodes/src/components/nodes/generic-node/components/GenericNodeRuntimeMessage.tsx
+++ b/packages/nodes/src/components/nodes/generic-node/components/GenericNodeRuntimeMessage.tsx
@@ -3,6 +3,7 @@ import type { DocumentNode } from '@nodepen/core'
 import { useRuntimeMessages } from '../../hooks'
 import { COLORS, DIMENSIONS } from '@/constants'
 import { useImperativeEvent } from '@/hooks'
+import { getNodeRuntimeMessageBubble } from '@/utils/node-geometry'
 
 type GenericNodeRuntimeMessageProps = {
   node: DocumentNode
@@ -15,15 +16,23 @@ export const GenericNodeRuntimeMessage = ({ node }: GenericNodeRuntimeMessagePro
   const messageContainerRef = useRef<SVGGElement>(null)
 
   const messages = useRuntimeMessages(instanceId)
+  const messageLevel = messages?.[0]?.level ?? 'info'
+
+  const messageColor: Record<typeof messageLevel, string> = {
+    error: COLORS.ERROR,
+    warn: COLORS.WARN,
+    info: COLORS.GREEN,
+  }
 
   // Position of bottom-middle arrow "point"
   const dx = anchors['labelDeltaX'].dx
   const dy = -9
 
-  const BUBBLE_SIZE = DIMENSIONS.NODE_LABEL_WIDTH + 2
+  const s = DIMENSIONS.NODE_RUNTIME_MESSAGE_BUBBLE_SIZE
 
   const handlePointerDown = useCallback((e: PointerEvent) => {
     e.stopPropagation()
+    console.log(messages[0]?.message)
 
     // TODO: Show message somehow
   }, [])
@@ -32,35 +41,13 @@ export const GenericNodeRuntimeMessage = ({ node }: GenericNodeRuntimeMessagePro
 
   return (
     <g ref={messageContainerRef}>
+      {getNodeRuntimeMessageBubble(node, COLORS.ERROR)}
       <rect
-        style={{
-          transform: 'rotate(45deg)',
-          transformOrigin: `${x + dx}px ${y + dy - BUBBLE_SIZE / 4}px`,
-        }}
-        x={x + dx - BUBBLE_SIZE / 4}
-        y={y + dy - BUBBLE_SIZE / 2}
-        width={BUBBLE_SIZE / 2}
-        height={BUBBLE_SIZE / 2}
-        fill={COLORS.ERROR}
-        rx={2}
-        ry={2}
-      />
-      <rect
-        x={x + dx - BUBBLE_SIZE / 2}
-        y={y + dy - 6 - BUBBLE_SIZE}
-        width={BUBBLE_SIZE}
-        height={BUBBLE_SIZE}
-        fill={COLORS.ERROR}
-        rx={6}
-        ry={6}
-      />
-      <rect
-        className="np-fill-error hover:np-fill-error-2 hover:np-cursor-pointer np-pointer-events-auto"
-        x={x + dx + 3 - BUBBLE_SIZE / 2}
-        y={y + dy - 3 - BUBBLE_SIZE}
-        width={BUBBLE_SIZE - 6}
-        height={BUBBLE_SIZE - 6}
-        fill={COLORS.DARKGREEN}
+        className={`np-fill-error hover:np-fill-error-2 hover:np-cursor-pointer np-pointer-events-auto`}
+        x={x + dx + 3 - s / 2}
+        y={y + dy - 3 - s}
+        width={s - 6}
+        height={s - 6}
         rx={3}
         ry={3}
       />

--- a/packages/nodes/src/components/nodes/generic-node/components/GenericNodeRuntimeMessage.tsx
+++ b/packages/nodes/src/components/nodes/generic-node/components/GenericNodeRuntimeMessage.tsx
@@ -5,6 +5,7 @@ import { COLORS, DIMENSIONS } from '@/constants'
 import { useImperativeEvent } from '@/hooks'
 import { getNodeRuntimeMessageBubble } from '@/utils/node-geometry'
 import { WiresMaskPortal } from '@/components/annotations/wire/components'
+import { Dialog } from '@/views/components'
 
 type GenericNodeRuntimeMessageProps = {
   node: DocumentNode
@@ -13,6 +14,8 @@ type GenericNodeRuntimeMessageProps = {
 export const GenericNodeRuntimeMessage = ({ node }: GenericNodeRuntimeMessageProps) => {
   const { instanceId, anchors, position } = node
   const { x, y } = position
+
+  const [showDialog, setShowDialog] = useState(false)
 
   const messageContainerRef = useRef<SVGGElement>(null)
 
@@ -33,6 +36,7 @@ export const GenericNodeRuntimeMessage = ({ node }: GenericNodeRuntimeMessagePro
       console.log(messages[0]?.message)
 
       // TODO: Show message somehow
+      setShowDialog(true)
     },
     [messages]
   )
@@ -86,6 +90,11 @@ export const GenericNodeRuntimeMessage = ({ node }: GenericNodeRuntimeMessagePro
           {getNodeRuntimeMessageBubble(node, '#FFFFFF')}
         </g>
       </WiresMaskPortal>
+      {showDialog ? (
+        <Dialog onClose={() => setShowDialog(false)}>
+          <p>{messages[0].message}</p>
+        </Dialog>
+      ) : null}
     </>
   )
 }

--- a/packages/nodes/src/components/nodes/generic-node/components/GenericNodeRuntimeMessage.tsx
+++ b/packages/nodes/src/components/nodes/generic-node/components/GenericNodeRuntimeMessage.tsx
@@ -1,0 +1,69 @@
+import React, { useCallback, useRef } from 'react'
+import type { DocumentNode } from '@nodepen/core'
+import { useRuntimeMessages } from '../../hooks'
+import { COLORS, DIMENSIONS } from '@/constants'
+import { useImperativeEvent } from '@/hooks'
+
+type GenericNodeRuntimeMessageProps = {
+  node: DocumentNode
+}
+
+export const GenericNodeRuntimeMessage = ({ node }: GenericNodeRuntimeMessageProps) => {
+  const { instanceId, anchors, position } = node
+  const { x, y } = position
+
+  const messageContainerRef = useRef<SVGGElement>(null)
+
+  const messages = useRuntimeMessages(instanceId)
+
+  // Position of bottom-middle arrow "point"
+  const dx = anchors['labelDeltaX'].dx
+  const dy = -9
+
+  const BUBBLE_SIZE = DIMENSIONS.NODE_LABEL_WIDTH + 2
+
+  const handlePointerDown = useCallback((e: PointerEvent) => {
+    e.stopPropagation()
+
+    // TODO: Show message somehow
+  }, [])
+
+  useImperativeEvent(messageContainerRef, 'pointerdown', handlePointerDown)
+
+  return (
+    <g ref={messageContainerRef}>
+      <rect
+        style={{
+          transform: 'rotate(45deg)',
+          transformOrigin: `${x + dx}px ${y + dy - BUBBLE_SIZE / 4}px`,
+        }}
+        x={x + dx - BUBBLE_SIZE / 4}
+        y={y + dy - BUBBLE_SIZE / 2}
+        width={BUBBLE_SIZE / 2}
+        height={BUBBLE_SIZE / 2}
+        fill={COLORS.ERROR}
+        rx={2}
+        ry={2}
+      />
+      <rect
+        x={x + dx - BUBBLE_SIZE / 2}
+        y={y + dy - 6 - BUBBLE_SIZE}
+        width={BUBBLE_SIZE}
+        height={BUBBLE_SIZE}
+        fill={COLORS.ERROR}
+        rx={6}
+        ry={6}
+      />
+      <rect
+        className="np-fill-error hover:np-fill-error-2 hover:np-cursor-pointer np-pointer-events-auto"
+        x={x + dx + 3 - BUBBLE_SIZE / 2}
+        y={y + dy - 3 - BUBBLE_SIZE}
+        width={BUBBLE_SIZE - 6}
+        height={BUBBLE_SIZE - 6}
+        fill={COLORS.DARKGREEN}
+        rx={3}
+        ry={3}
+      />
+    </g>
+  )
+}

--- a/packages/nodes/src/components/nodes/generic-node/components/GenericNodeRuntimeMessage.tsx
+++ b/packages/nodes/src/components/nodes/generic-node/components/GenericNodeRuntimeMessage.tsx
@@ -84,6 +84,28 @@ export const GenericNodeRuntimeMessage = ({ node }: GenericNodeRuntimeMessagePro
           rx={3}
           ry={3}
         />
+        <svg
+          width={24}
+          height={24}
+          style={{
+            transform: `translate(${node.position.x + node.anchors['labelDeltaX'].dx - 12}px, ${node.position.y - 44
+              }px)`,
+          }}
+          aria-hidden="true"
+          fill="none"
+          stroke={COLORS.DARK}
+          strokeWidth="2"
+          viewBox="0 0 24 24"
+          xmlns="http://www.w3.org/2000/svg"
+          className="np-pointer-events-none"
+        >
+          <path
+            d="M12 9v3.75m9-.75a9 9 0 11-18 0 9 9 0 0118 0zm-9 3.75h.008v.008H12v-.008z"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            vectorEffect="non-scaling-stroke"
+          ></path>
+        </svg>
       </g>
       <WiresMaskPortal>
         <g className="np-transition-transform np-duration-300 np-ease-out" style={{ transform: `translateY(${tx}px)` }}>
@@ -92,7 +114,7 @@ export const GenericNodeRuntimeMessage = ({ node }: GenericNodeRuntimeMessagePro
       </WiresMaskPortal>
       {showDialog ? (
         <Dialog onClose={() => setShowDialog(false)}>
-          <p>{messages[0].message}</p>
+          <p className="np-font-sans np-font-medium np-text-dark np-text-md">{messages[0].message}</p>
         </Dialog>
       ) : null}
     </>

--- a/packages/nodes/src/components/nodes/generic-node/components/GenericNodeRuntimeMessage.tsx
+++ b/packages/nodes/src/components/nodes/generic-node/components/GenericNodeRuntimeMessage.tsx
@@ -17,9 +17,11 @@ export const GenericNodeRuntimeMessage = ({ node }: GenericNodeRuntimeMessagePro
   const messageContainerRef = useRef<SVGGElement>(null)
 
   const messages = useRuntimeMessages(instanceId)
-  const messageLevel = messages?.[0]?.level ?? 'info'
 
-  const messageColor: Record<typeof messageLevel, string> = {
+  const currentMessage = messages[0]
+  const currentMessageLevel = currentMessage?.level
+
+  const messageColors: Record<typeof currentMessageLevel, string> = {
     error: COLORS.ERROR,
     warning: COLORS.WARN,
     info: COLORS.GREEN,
@@ -43,12 +45,19 @@ export const GenericNodeRuntimeMessage = ({ node }: GenericNodeRuntimeMessagePro
 
   useImperativeEvent(messageContainerRef, 'pointerdown', handlePointerDown)
 
+  if (!currentMessage) {
+    return null
+  }
+
   return (
     <>
       <g ref={messageContainerRef}>
-        {getNodeRuntimeMessageBubble(node, COLORS.ERROR)}
+        {getNodeRuntimeMessageBubble(node, messageColors[currentMessageLevel])}
         <rect
-          className={`np-fill-error hover:np-fill-error-2 hover:np-cursor-pointer np-pointer-events-auto`}
+          className={`${currentMessageLevel === 'error'
+              ? 'np-fill-error hover:np-fill-error-2'
+              : 'np-fill-warn hover:np-fill-warn-2'
+            }  hover:np-cursor-pointer np-pointer-events-auto`}
           x={x + dx + 3 - s / 2}
           y={y + dy - 3 - s}
           width={s - 6}

--- a/packages/nodes/src/components/nodes/generic-node/components/GenericNodeRuntimeMessage.tsx
+++ b/packages/nodes/src/components/nodes/generic-node/components/GenericNodeRuntimeMessage.tsx
@@ -4,6 +4,7 @@ import { useRuntimeMessages } from '../../hooks'
 import { COLORS, DIMENSIONS } from '@/constants'
 import { useImperativeEvent } from '@/hooks'
 import { getNodeRuntimeMessageBubble } from '@/utils/node-geometry'
+import { WiresMaskPortal } from '@/components/annotations/wire/components'
 
 type GenericNodeRuntimeMessageProps = {
   node: DocumentNode
@@ -20,7 +21,7 @@ export const GenericNodeRuntimeMessage = ({ node }: GenericNodeRuntimeMessagePro
 
   const messageColor: Record<typeof messageLevel, string> = {
     error: COLORS.ERROR,
-    warn: COLORS.WARN,
+    warning: COLORS.WARN,
     info: COLORS.GREEN,
   }
 
@@ -30,27 +31,35 @@ export const GenericNodeRuntimeMessage = ({ node }: GenericNodeRuntimeMessagePro
 
   const s = DIMENSIONS.NODE_RUNTIME_MESSAGE_BUBBLE_SIZE
 
-  const handlePointerDown = useCallback((e: PointerEvent) => {
-    e.stopPropagation()
-    console.log(messages[0]?.message)
+  const handlePointerDown = useCallback(
+    (e: PointerEvent) => {
+      e.stopPropagation()
+      console.log(messages[0]?.message)
 
-    // TODO: Show message somehow
-  }, [])
+      // TODO: Show message somehow
+    },
+    [messages]
+  )
 
   useImperativeEvent(messageContainerRef, 'pointerdown', handlePointerDown)
 
   return (
-    <g ref={messageContainerRef}>
-      {getNodeRuntimeMessageBubble(node, COLORS.ERROR)}
-      <rect
-        className={`np-fill-error hover:np-fill-error-2 hover:np-cursor-pointer np-pointer-events-auto`}
-        x={x + dx + 3 - s / 2}
-        y={y + dy - 3 - s}
-        width={s - 6}
-        height={s - 6}
-        rx={3}
-        ry={3}
-      />
-    </g>
+    <>
+      <g ref={messageContainerRef}>
+        {getNodeRuntimeMessageBubble(node, COLORS.ERROR)}
+        <rect
+          className={`np-fill-error hover:np-fill-error-2 hover:np-cursor-pointer np-pointer-events-auto`}
+          x={x + dx + 3 - s / 2}
+          y={y + dy - 3 - s}
+          width={s - 6}
+          height={s - 6}
+          rx={3}
+          ry={3}
+        />
+      </g>
+      <WiresMaskPortal>
+        <g>{getNodeRuntimeMessageBubble(node, '#FFFFFF')}</g>
+      </WiresMaskPortal>
+    </>
   )
 }

--- a/packages/nodes/src/components/nodes/generic-node/components/index.ts
+++ b/packages/nodes/src/components/nodes/generic-node/components/index.ts
@@ -1,6 +1,7 @@
 export { GenericNodeBody } from './GenericNodeBody'
 export { GenericNodeLabel } from './GenericNodeLabel'
 export { GenericNodePorts } from './GenericNodePorts'
+export { GenericNodeRuntimeMessage } from './GenericNodeRuntimeMessage'
 export { GenericNodeShadow } from './GenericNodeShadow'
 export { GenericNodeSkeleton } from './GenericNodeSkeleton'
 export { GenericNodeWires } from './GenericNodeWires'

--- a/packages/nodes/src/components/nodes/hooks/index.ts
+++ b/packages/nodes/src/components/nodes/hooks/index.ts
@@ -1,4 +1,5 @@
 export { useDebugRender } from './useDebugRender'
 export { useDraggableNode } from './useDraggableNode'
 export { usePort } from './usePort'
+export { useRuntimeMessages } from './useRuntimeMessages'
 export { useSelectableNode } from './useSelectableNode'

--- a/packages/nodes/src/components/nodes/hooks/useRuntimeMessages.ts
+++ b/packages/nodes/src/components/nodes/hooks/useRuntimeMessages.ts
@@ -1,0 +1,10 @@
+import type { NodeSolutionData } from '@nodepen/core'
+import { useStore } from '$'
+
+export const useRuntimeMessages = (nodeInstanceId: string): NodeSolutionData['nodeRuntimeData']['messages'] => {
+  return useStore(
+    (state) =>
+      state.solution.nodeSolutionData.find((nodeSolution) => nodeSolution.nodeInstanceId === nodeInstanceId)
+        ?.nodeRuntimeData?.messages ?? []
+  )
+}

--- a/packages/nodes/src/components/nodes/hooks/useRuntimeMessages.ts
+++ b/packages/nodes/src/components/nodes/hooks/useRuntimeMessages.ts
@@ -1,10 +1,31 @@
+import { useRef } from 'react'
 import type { NodeSolutionData } from '@nodepen/core'
 import { useStore } from '$'
 
+/**
+ * Returns the latest runtime messages for the given document node.
+ * @remarks While solution lifecycle status is `expired`, returns a cached version of the previous solution's messages.
+ */
 export const useRuntimeMessages = (nodeInstanceId: string): NodeSolutionData['nodeRuntimeData']['messages'] => {
-  return useStore(
-    (state) =>
-      state.solution.nodeSolutionData.find((nodeSolution) => nodeSolution.nodeInstanceId === nodeInstanceId)
-        ?.nodeRuntimeData?.messages ?? []
-  )
+  const previousMessages = useRef<NodeSolutionData['nodeRuntimeData']['messages']>([])
+
+  return useStore((state) => {
+    if (state.lifecycle.solution === 'expired') {
+      return previousMessages.current
+    }
+
+    const nodeSolutionData = state.solution.nodeSolutionData.find(
+      (nodeSolution) => nodeSolution.nodeInstanceId === nodeInstanceId
+    )
+
+    if (!nodeSolutionData) {
+      return []
+    }
+
+    const nodeRuntimeMessages = nodeSolutionData.nodeRuntimeData.messages
+
+    previousMessages.current = nodeRuntimeMessages
+
+    return nodeRuntimeMessages
+  })
 }

--- a/packages/nodes/src/constants.ts
+++ b/packages/nodes/src/constants.ts
@@ -18,6 +18,7 @@ export const COLORS = {
   DARKGREEN: '#093824',
   /* Special */
   ERROR: '#FF7171',
+  ERRORDARK: '#DD6363',
   WARN: '#FFBE71',
 } as const
 

--- a/packages/nodes/src/constants.ts
+++ b/packages/nodes/src/constants.ts
@@ -20,6 +20,7 @@ export const COLORS = {
   ERROR: '#FF7171',
   ERRORDARK: '#DD6363',
   WARN: '#FFBE71',
+  WARNDARK: '#E3AF71',
 } as const
 
 export const DIMENSIONS = {
@@ -32,6 +33,8 @@ export const DIMENSIONS = {
   NODE_PORT_HEIGHT: 40,
   NODE_PORT_MINIMUM_WIDTH: 50,
   NODE_PORT_RADIUS: 5,
+  /** NODE_LABEL_WIDTH + 2 */
+  NODE_RUNTIME_MESSAGE_BUBBLE_SIZE: 34,
 } as const
 
 export const STYLES = {

--- a/packages/nodes/src/store/state.ts
+++ b/packages/nodes/src/store/state.ts
@@ -42,6 +42,7 @@ export type NodesAppState = {
     contextMenus: {
       [menuKey: string]: ContextMenu
     }
+    dialogRoot: React.RefObject<HTMLDivElement>
     shadows: {
       containerRef: React.RefObject<HTMLDivElement> | null
       proxyRefs: {
@@ -180,6 +181,7 @@ export const initialState: NodesAppState = {
   registry: {
     canvasRoot: React.createRef<HTMLDivElement>(),
     contextMenus: {},
+    dialogRoot: React.createRef<HTMLDivElement>(),
     shadows: {
       containerRef: null,
       proxyRefs: {

--- a/packages/nodes/src/utils/node-dimensions/getNodeDimensions.ts
+++ b/packages/nodes/src/utils/node-dimensions/getNodeDimensions.ts
@@ -8,7 +8,12 @@ export const getNodeDimensions = (
   nodeTemplate: NodePen.NodeTemplate
 ): Pick<NodePen.DocumentNode, 'anchors' | 'dimensions'> => {
   const nodeDimensions: Pick<NodePen.DocumentNode, 'anchors' | 'dimensions'> = {
-    anchors: {},
+    anchors: {
+      labelDeltaX: {
+        dx: 0,
+        dy: 0,
+      },
+    },
     dimensions: {
       width: 0,
       height: 0,

--- a/packages/nodes/src/utils/node-geometry/getNodeRuntimeMessageBubble.tsx
+++ b/packages/nodes/src/utils/node-geometry/getNodeRuntimeMessageBubble.tsx
@@ -1,0 +1,33 @@
+import React from 'react'
+import type { DocumentNode } from '@nodepen/core'
+import { DIMENSIONS } from '@/constants'
+
+export const getNodeRuntimeMessageBubble = (node: DocumentNode, fillColor: string) => {
+  const { anchors, position } = node
+  const { x, y } = position
+
+  // Position of bottom-middle arrow "point"
+  const dx = anchors['labelDeltaX'].dx
+  const dy = -9
+
+  const s = DIMENSIONS.NODE_RUNTIME_MESSAGE_BUBBLE_SIZE
+
+  return (
+    <>
+      <rect
+        style={{
+          transform: 'rotate(45deg)',
+          transformOrigin: `${x + dx}px ${y + dy - s / 4}px`,
+        }}
+        x={x + dx - s / 4}
+        y={y + dy - s / 2}
+        width={s / 2}
+        height={s / 2}
+        fill={fillColor}
+        rx={2}
+        ry={2}
+      />
+      <rect x={x + dx - s / 2} y={y + dy - 6 - s} width={s} height={s} fill={fillColor} rx={6} ry={6} />
+    </>
+  )
+}

--- a/packages/nodes/src/utils/node-geometry/index.ts
+++ b/packages/nodes/src/utils/node-geometry/index.ts
@@ -1,0 +1,1 @@
+export { getNodeRuntimeMessageBubble } from './getNodeRuntimeMessageBubble'

--- a/packages/nodes/src/utils/templates/createInstance.ts
+++ b/packages/nodes/src/utils/templates/createInstance.ts
@@ -20,7 +20,12 @@ export const createInstance = (template: NodePen.NodeTemplate): NodePen.Document
       isEnabled: true,
       isProvisional: false,
     },
-    anchors: {},
+    anchors: {
+      labelDeltaX: {
+        dx: 0,
+        dy: 0,
+      },
+    },
     values: {},
     sources: {},
     inputs: {},

--- a/packages/nodes/src/views/components/dialog/Dialog.tsx
+++ b/packages/nodes/src/views/components/dialog/Dialog.tsx
@@ -16,6 +16,7 @@ export const Dialog = ({ title, onClose, children }: DialogProps) => {
           onClick={() => {
             onClose()
           }}
+          role="presentation"
         ></div>
         <div className="np-absolute np-left-0 np-top-0 np-w-full np-h-full np-z-10 np-pointer-events-none">
           <div className="np-w-full np-h-full np-flex np-justify-center np-items-center">

--- a/packages/nodes/src/views/components/dialog/Dialog.tsx
+++ b/packages/nodes/src/views/components/dialog/Dialog.tsx
@@ -1,0 +1,31 @@
+import React from 'react'
+import { DialogPortal } from './DialogPortal'
+
+type DialogProps = {
+  title?: string
+  children: React.ReactNode
+  onClose: () => void
+}
+
+export const Dialog = ({ title, onClose, children }: DialogProps) => {
+  return (
+    <DialogPortal>
+      <div className="np-relative np-w-full np-h-full np-pointer-events-auto">
+        <div
+          className="np-absolute np-left-0 np-top-0 np-w-full np-h-full np-z-0 np-bg-error"
+          onClick={() => {
+            console.log('!')
+            onClose()
+          }}
+        ></div>
+        <div className="np-absolute np-left-0 np-top-0 np-w-full np-h-full np-z-10 np-pointer-events-none">
+          <div className="np-w-full np-h-full np-flex np-justify-center np-items-center">
+            <div className="np-w-96 np-h-24 np-p-4 np-bg-light np-rounded-md np-shadow-main np-pointer-events-auto">
+              {children}
+            </div>
+          </div>
+        </div>
+      </div>
+    </DialogPortal>
+  )
+}

--- a/packages/nodes/src/views/components/dialog/Dialog.tsx
+++ b/packages/nodes/src/views/components/dialog/Dialog.tsx
@@ -12,15 +12,18 @@ export const Dialog = ({ title, onClose, children }: DialogProps) => {
     <DialogPortal>
       <div className="np-relative np-w-full np-h-full np-pointer-events-auto">
         <div
-          className="np-absolute np-left-0 np-top-0 np-w-full np-h-full np-z-0 np-bg-error"
+          className="np-absolute np-left-0 np-top-0 np-w-full np-h-full np-z-0 np-bg-dark np-bg-opacity-30 hover:np-bg-opacity-40 np-transition-all np-duration-300 np-ease-out"
           onClick={() => {
-            console.log('!')
             onClose()
           }}
         ></div>
         <div className="np-absolute np-left-0 np-top-0 np-w-full np-h-full np-z-10 np-pointer-events-none">
           <div className="np-w-full np-h-full np-flex np-justify-center np-items-center">
-            <div className="np-w-96 np-h-24 np-p-4 np-bg-light np-rounded-md np-shadow-main np-pointer-events-auto">
+            <div
+              className="np-w-96 np-p-4 np-bg-light np-rounded-md np-shadow-modal np-pointer-events-auto"
+              onPointerDown={(e) => e.stopPropagation()}
+              onDoubleClick={(e) => e.stopPropagation()}
+            >
               {children}
             </div>
           </div>

--- a/packages/nodes/src/views/components/dialog/DialogPortal.tsx
+++ b/packages/nodes/src/views/components/dialog/DialogPortal.tsx
@@ -1,0 +1,17 @@
+import type React from 'react'
+import { createPortal } from 'react-dom'
+import { useStore } from '$'
+
+type DialogPortalProps = {
+  children: React.ReactNode
+}
+
+export const DialogPortal = ({ children }: DialogPortalProps) => {
+  const dialogContainerRef = useStore((state) => state.registry.dialogRoot)
+
+  if (!dialogContainerRef || !dialogContainerRef.current) {
+    return null
+  }
+
+  return createPortal(children, dialogContainerRef.current)
+}

--- a/packages/nodes/src/views/components/dialog/index.ts
+++ b/packages/nodes/src/views/components/dialog/index.ts
@@ -1,0 +1,1 @@
+export { Dialog } from './Dialog'

--- a/packages/nodes/src/views/components/index.ts
+++ b/packages/nodes/src/views/components/index.ts
@@ -1,0 +1,1 @@
+export { Dialog } from './dialog'

--- a/packages/nodes/src/views/document-view/layers/transient-element-overlay/tooltips/port-tooltip/PortTooltip.tsx
+++ b/packages/nodes/src/views/document-view/layers/transient-element-overlay/tooltips/port-tooltip/PortTooltip.tsx
@@ -64,19 +64,21 @@ export const PortTooltip = ({ tooltipKey, configuration, context }: PortTooltipP
         icon={dataIcon}
         border
       >
-        <div
-          className="np-w-full np-transition-all np-duration-300 np-overflow-hidden"
-          style={{ maxHeight: values ? (values.stats.treeStructure === 'single' ? 128 : 512) : 20 }}
-        >
-          {values ? (
-            <>
-              <p className="np-mt-1 np-mb-2 np-font-sans np-font-medius np-text-dark np-text-xs">
-                {getDataTreeSummary(values)}
-              </p>
-              <DataTreePreview dataTree={values} />
-            </>
-          ) : null}
-        </div>
+        {values?.stats.treeStructure !== 'empty' ? (
+          <div
+            className="np-w-full np-transition-all np-duration-300 np-overflow-hidden"
+            style={{ maxHeight: values ? (values.stats.treeStructure === 'single' ? 128 : 512) : 20 }}
+          >
+            {values ? (
+              <>
+                <p className="np-mt-1 np-mb-2 np-font-sans np-font-medius np-text-dark np-text-xs">
+                  {getDataTreeSummary(values)}
+                </p>
+                <DataTreePreview dataTree={values} />
+              </>
+            ) : null}
+          </div>
+        ) : null}
       </MenuSection>
     </div>
   )

--- a/packages/nodes/src/views/static/dialog-layer/StaticDialogLayer.tsx
+++ b/packages/nodes/src/views/static/dialog-layer/StaticDialogLayer.tsx
@@ -1,0 +1,13 @@
+import React from 'react'
+import { useStore } from '$'
+import { Layer } from '@/views/common'
+
+export const StaticDialogLayer = () => {
+  const dialogContainerRef = useStore((store) => store.registry.dialogRoot)
+
+  return (
+    <Layer id="np-dialog-layer" z={99} fixed>
+      <div className="np-pointer-events-none np-w-full np-h-full" ref={dialogContainerRef} />
+    </Layer>
+  )
+}

--- a/packages/nodes/src/views/static/dialog-layer/index.ts
+++ b/packages/nodes/src/views/static/dialog-layer/index.ts
@@ -1,0 +1,1 @@
+export { StaticDialogLayer } from './StaticDialogLayer'

--- a/packages/nodes/tailwind.config.js
+++ b/packages/nodes/tailwind.config.js
@@ -13,7 +13,8 @@ module.exports = {
       "darkgreen": "#093824",
       "error": "#FF7171",
       "error-2": "#DD6363",
-      "warn": "#FFBE71"
+      "warn": "#FFBE71",
+      "warn-2": "#E3AF71",
     },
     fontFamily: {
       'sans': ['Barlow', 'ui-sans-serif'],

--- a/packages/nodes/tailwind.config.js
+++ b/packages/nodes/tailwind.config.js
@@ -42,6 +42,7 @@ module.exports = {
       },
       boxShadow: {
         main: '-2px 2px 0 0 rgba(123, 191, 165, 0.3)',
+        modal: '-4px 4px 0 0 rgba(65, 65, 65, 0.3)',
         input: 'inset -2px 2px 0px 0px rgba(123, 191, 165, 0.3)'
       },
       height: {

--- a/packages/nodes/tailwind.config.js
+++ b/packages/nodes/tailwind.config.js
@@ -12,6 +12,7 @@ module.exports = {
       "swampgreen": "#7BBFA5",
       "darkgreen": "#093824",
       "error": "#FF7171",
+      "error-2": "#DD6363",
       "warn": "#FFBE71"
     },
     fontFamily: {


### PR DESCRIPTION
One last lil feature sneaking in at the last minute: surface runtime warnings/errors with a (very) bare-bones modal interaction. The expando-bubble from the last version was cute, but this will play nicer with future plans.

resolves #386 